### PR TITLE
Normalize workflow paths in Python pipeline scripts

### DIFF
--- a/1_import_following.py
+++ b/1_import_following.py
@@ -1,9 +1,12 @@
 # Import relevant libraries
 import pandas as pd
 import os
+from pathlib import Path
 
-# working directory to the parent directory of the script's location
-os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# working directory to the repository root
+repo_root = Path(__file__).resolve().parent
+os.chdir(repo_root)
+Path("processed").mkdir(parents=True, exist_ok=True)
 
 # Load the CSV file
 follows = pd.read_csv("input/snapshot-hub-mainnet-2023-08-30-follows_0.csv")

--- a/2_import_spaces.py
+++ b/2_import_spaces.py
@@ -4,9 +4,12 @@ import pandas as pd
 import numpy as np
 import json
 import os
+from pathlib import Path
 
-# working directory to the parent directory of the script's location
-os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# working directory to the repository root
+repo_root = Path(__file__).resolve().parent
+os.chdir(repo_root)
+Path("processed").mkdir(parents=True, exist_ok=True)
 
 # Load the CSV file
 spaces = pd.read_csv("input/snapshot-hub-mainnet-2023-08-30-spaces_0.csv")

--- a/3_1_import_forum.py
+++ b/3_1_import_forum.py
@@ -7,10 +7,16 @@ import re
 import requests
 import time
 import validators
+from pathlib import Path
 
 from bs4 import BeautifulSoup
 from seleniumbase import SB
 
+
+repo_root = Path(__file__).resolve().parent
+os.chdir(repo_root)
+Path("csvs").mkdir(parents=True, exist_ok=True)
+Path("json").mkdir(parents=True, exist_ok=True)
 
 # load propositions
 props = pd.read_csv("input/snapshot-hub-mainnet-2023-08-30-proposals_0.csv", low_memory=False)

--- a/3_import_voter.py
+++ b/3_import_voter.py
@@ -2,9 +2,12 @@
 import pandas as pd
 import json
 import os
+from pathlib import Path
 
-# working directory to the parent directory of the script's location
-os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# working directory to the repository root
+repo_root = Path(__file__).resolve().parent
+os.chdir(repo_root)
+Path("processed").mkdir(parents=True, exist_ok=True)
 
 # Load the users CSV file into a DataFrame
 users = pd.read_csv("input/snapshot-hub-mainnet-2023-08-30-users_0.csv")

--- a/4_import_proposals.py
+++ b/4_import_proposals.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import json
 import os
+from pathlib import Path
 import ast
 from itertools import zip_longest
 from sklearn.feature_extraction.text import CountVectorizer
@@ -28,8 +29,10 @@ n_topics = 20
 
 no_top_words = 10
 
-# working directory to the parent directory of the script's location
-# os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# working directory to the repository root
+repo_root = Path(__file__).resolve().parent
+os.chdir(repo_root)
+Path("processed").mkdir(parents=True, exist_ok=True)
 
 # load propos
 props = pd.read_csv(

--- a/5_import_votes.py
+++ b/5_import_votes.py
@@ -4,9 +4,12 @@ import pandas as pd
 import numpy as np
 import json
 import os
+from pathlib import Path
 
-# working directory to the parent directory of the script's location
-os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# working directory to the repository root
+repo_root = Path(__file__).resolve().parent
+os.chdir(repo_root)
+Path("processed").mkdir(parents=True, exist_ok=True)
 
 votes = pd.read_csv(
     "input/snapshot-hub-mainnet-2023-08-30-votes_0.csv", low_memory=False

--- a/5a_discourse_extract_core.py
+++ b/5a_discourse_extract_core.py
@@ -13,7 +13,9 @@
 
 import json
 import re
+import os
 from collections import defaultdict
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -21,6 +23,10 @@ import pandas as pd
 # -----------------------------
 # URL canonicalization (for reliable join)
 # -----------------------------
+repo_root = Path(__file__).resolve().parent
+os.chdir(repo_root)
+Path("csvs").mkdir(parents=True, exist_ok=True)
+
 def canonicalize_url(u) -> str:
     if u is None:
         return ""

--- a/6_import_and_merge.py
+++ b/6_import_and_merge.py
@@ -9,7 +9,7 @@ import numpy as np
 # 0. Setup
 # ------------------------------------------------------------
 # run relative to repo root
-os.chdir(Path(__file__).resolve().parent.parent)
+os.chdir(Path(__file__).resolve().parent)
 
 # keep-only column whitelist
 required_columns = [


### PR DESCRIPTION
### Motivation
- Ensure all pipeline and helper scripts run from a consistent working directory to avoid file-not-found and path-resolution errors when invoked from different locations. 
- Create required output directories before writing so the end-to-end workflow does not fail due to missing folders. 
- Make forum/discourse helper scripts use the same repo-root behavior so scraping and JSON export consistently write to `csvs`/`json` paths. 

### Description
- Updated multiple scripts to set the working directory using `repo_root = Path(__file__).resolve().parent` and `os.chdir(repo_root)` for consistent path resolution across the pipeline. 
- Ensure output locations exist by creating directories with `Path(...).mkdir(parents=True, exist_ok=True)` in `processed`, `csvs`, and `json` where applicable. 
- Adjusted `6_import_and_merge.py` to run relative to its script directory by changing `os.chdir(Path(__file__).resolve().parent.parent)` to `os.chdir(Path(__file__).resolve().parent)`. 
- Changes applied to `1_import_following.py`, `2_import_spaces.py`, `3_1_import_forum.py`, `3_import_voter.py`, `4_import_proposals.py`, `5_import_votes.py`, `5a_discourse_extract_core.py`, and `6_import_and_merge.py`. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972603c28548330a5faf6564a8d1e27)